### PR TITLE
qiita のバッチのリンクが切れていたので修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # statistics
 [![Articles](https://badgen.org/img/zenn/honahuku/articles?style=flat)](https://zenn.dev/honahuku)
 [![Scraps](https://badgen.org/img/zenn/honahuku/scraps?style=flat)](https://zenn.dev/honahuku?tab=scraps)
-[![Posts](https://qiita-badge.apiapi.app/s/honahuku/posts.svg)](https://qiita.com/honahuku)
-[![Contributions](https://qiita-badge.apiapi.app/s/honahuku/contributions.svg)](https://qiita.com/honahuku)
+[![Contributions](https://badgen.org/img/qiita/honahuku/contributions?style=flat)](https://qiita.com/honahuku)
+[![Articles](https://badgen.org/img/qiita/honahuku/articles?style=flat)](https://qiita.com/honahuku)
 ![](https://komarev.com/ghpvc/?username=honahuku&color=yellowgreen&style=flat&label=GitHub+profile+views)
 <!-- [![misskey](https://badgen.net/badge/misskey/:status/cyan)](https://qiita.com/honahuku) -->
 


### PR DESCRIPTION
qiita のバッチのリンクが切れていたので [Badge Generator](https://badgen.org/) に置き換えた
